### PR TITLE
Specify lxml when creating the BeautifulSoap parser

### DIFF
--- a/backlinks_plugin/plugin.py
+++ b/backlinks_plugin/plugin.py
@@ -29,7 +29,7 @@ class LinkScraper:
         named anchor and will not point to an external page.
         :return: a list of valid links.
         """
-        links = BeautifulSoup(self.html).find_all('a')
+        links = BeautifulSoup(self.html, feature='lxml').find_all('a')
         return self.__remove_invalid_links(links)
 
     def __remove_invalid_links(self, links):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='mkdocs-backlinks',
-    version='0.9.1',
+    version='0.9.2',
     description='A MkDocs plugin for adding backlinks to your documentation pages.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Adds the `lxml` parser explicitly to the BeautifulSoap initialization. Fixes #4.